### PR TITLE
fix: Time.AddDate with zero values has unintended consequences to the time at DST

### DIFF
--- a/arithmetic.go
+++ b/arithmetic.go
@@ -6,8 +6,9 @@ package period
 
 import (
 	"errors"
-	"github.com/govalues/decimal"
 	"time"
+
+	"github.com/govalues/decimal"
 )
 
 // AddTo adds the period to a time, returning the result.
@@ -20,13 +21,11 @@ import (
 //
 // However, when years, months or days contains fractions, the result is only an approximation (it
 // assumes that all days are 24 hours and every year is 365.2425 days, as per Gregorian calendar rules).
+//
+// Note: the use of AddDate has unintended consequences when considering the addition of a time only
+// period. See <https://x.com/joelmcourtney/status/1803301619955904979>.
 func (period Period) AddTo(t time.Time) (time.Time, bool) {
-	wholeYears := period.years.Scale() == 0
-	wholeMonths := period.months.Scale() == 0
-	wholeWeeks := period.weeks.Scale() == 0
-	wholeDays := period.days.Scale() == 0
-
-	if wholeYears && wholeMonths && wholeWeeks && wholeDays {
+	if !zeroCalendarValues(period) && wholeCalendarValues(period) {
 		// in this case, time.AddDate provides an exact solution
 
 		years, _, ok1 := period.years.Int64(0)
@@ -233,6 +232,25 @@ func fieldDuration(field decimal.Decimal, factor int64) (int64, bool) {
 	}
 
 	return int64(field.Sign()) * int64(field.Coef()) * factor, factor > 0
+}
+
+func wholeCalendarValues(period Period) bool {
+	zeroCalValue := zeroCalendarValues(period)
+	wholeYears := period.years.Scale() == 0
+	wholeMonths := period.months.Scale() == 0
+	wholeWeeks := period.weeks.Scale() == 0
+	wholeDays := period.days.Scale() == 0
+
+	return !zeroCalValue && wholeYears && wholeMonths && wholeWeeks && wholeDays
+}
+
+func zeroCalendarValues(period Period) bool {
+	zeroYears := period.years == decimal.Zero
+	zeroMonths := period.months == decimal.Zero
+	zeroWeeks := period.weeks == decimal.Zero
+	zeroDays := period.days == decimal.Zero
+
+	return zeroYears && zeroMonths && zeroWeeks && zeroDays
 }
 
 const (

--- a/arithmetic_test.go
+++ b/arithmetic_test.go
@@ -6,11 +6,12 @@ package period
 
 import (
 	"fmt"
-	"github.com/govalues/decimal"
-	. "github.com/onsi/gomega"
 	"math"
 	"testing"
 	"time"
+
+	"github.com/govalues/decimal"
+	. "github.com/onsi/gomega"
 )
 
 func Test_Add_Subtract(t *testing.T) {
@@ -82,12 +83,15 @@ func Test_AddTo(t *testing.T) {
 	const hour = 60 * minute
 
 	est := mustLoadLocation("America/New_York")
+	aest := mustLoadLocation("Australia/Sydney")
 
 	times := []time.Time{
 		// A conveniently round number but with non-zero nanoseconds (14 July 2017 @ 2:40am UTC)
 		time.Unix(1500000000, 1).UTC(),
 		// This specific time fails for EST due behaviour of time.Time.AddDate
 		time.Date(2020, 11, 1, 1, 0, 0, 0, est),
+		// Testing to ensure that adding zero with a DST day does not blow up due behaviour of time.Time.AddDate
+		time.Date(2024, 4, 6, 15, 0, 0, 0, time.UTC).In(aest),
 	}
 
 	for _, t0 := range times {


### PR DESCRIPTION
Resolves #2.