### PR TITLE
Add cross linking to package go doc comments

### DIFF
--- a/arithmetic.go
+++ b/arithmetic.go
@@ -54,7 +54,7 @@ func (period Period) AddTo(t time.Time) (time.Time, bool) {
 
 //-------------------------------------------------------------------------------------------------
 
-// Add adds two periods together. Use this method along with Negate in order to subtract periods.
+// Add adds two periods together. Use this method along with [Period.Negate] in order to subtract periods.
 // Arithmetic overflow will result in an error.
 func (period Period) Add(other Period) (Period, error) {
 	var left, right Period

--- a/format.go
+++ b/format.go
@@ -68,14 +68,14 @@ func writeField(w usefulWriter, field decimal.Decimal, fieldDesignator Designato
 
 //-------------------------------------------------------------------------------------------------
 
-// Format converts the period to human-readable form using DefaultFormatLocalisation.
-// To adjust the result, see the Normalise, NormaliseDaysToYears, Simplify and SimplifyWeeksToDays methods.
+// Format converts the period to human-readable form using [DefaultFormatLocalisation].
+// To adjust the result, see the [Period.Normalise], [Period.NormaliseDaysToYears], [Period.Simplify] and [Period.SimplifyWeeksToDays] methods.
 func (period Period) Format() string {
 	return period.FormatLocalised(DefaultFormatLocalisation)
 }
 
 // FormatLocalised converts the period to human-readable form in a localisable way.
-// To adjust the result, see the Normalise, NormaliseDaysToYears, Simplify and SimplifyWeeksToDays methods.
+// To adjust the result, see the [Period.Normalise], [Period.NormaliseDaysToYears], [Period.Simplify] and [Period.SimplifyWeeksToDays] methods.
 func (period Period) FormatLocalised(config FormatLocalisation) string {
 	if period.IsZero() {
 		return config.ZeroValue

--- a/marshal.go
+++ b/marshal.go
@@ -4,26 +4,26 @@
 
 package period
 
-// MarshalBinary implements the encoding.BinaryMarshaler interface.
+// MarshalBinary implements the [encoding.BinaryMarshaler] interface.
 // This also provides support for gob encoding.
 func (period Period) MarshalBinary() ([]byte, error) {
 	// binary method would take more space in many cases, so we simply use text
 	return period.MarshalText()
 }
 
-// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+// UnmarshalBinary implements the [encoding.BinaryUnmarshaler] interface.
 // This also provides support for gob decoding.
 func (period *Period) UnmarshalBinary(data []byte) error {
 	return period.UnmarshalText(data)
 }
 
-// MarshalText implements the encoding.TextMarshaler interface for Periods.
+// MarshalText implements the [encoding.TextMarshaler] interface for Periods.
 // This also provides support for JSON encoding.
 func (period Period) MarshalText() ([]byte, error) {
 	return []byte(period.String()), nil
 }
 
-// UnmarshalText implements the encoding.TextUnmarshaler interface for Periods.
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface for Periods.
 // This also provides support for JSON decoding.
 func (period *Period) UnmarshalText(data []byte) error {
 	u, err := Parse(string(data))

--- a/normalise.go
+++ b/normalise.go
@@ -30,7 +30,7 @@ var (
 //
 // If the calculations would lead to arithmetic errors, the current values are kept unaltered.
 //
-// See also NormaliseDaysToYears().
+// See also [Period.NormaliseDaysToYears].
 func (period Period) Normalise(precise bool) Period {
 	// first phase - ripple large numbers to the left
 	period.minutes, period.seconds = moveWholePartsLeft(period.minutes, period.seconds, sixty)
@@ -50,7 +50,7 @@ func (period Period) Normalise(precise bool) Period {
 //
 // If the calculations would lead to arithmetic errors, the current values are kept unaltered.
 //
-// A common use pattern would be to chain this after Normalise, i.e.
+// A common use pattern would be to chain this after [Period.Normalise], i.e.
 //
 //	p.Normalise(false).NormaliseDaysToYears()
 func (period Period) NormaliseDaysToYears() Period {
@@ -103,7 +103,7 @@ func moveWholePartsLeft(larger, smaller, nd decimal.Decimal) (decimal.Decimal, d
 //-------------------------------------------------------------------------------------------------
 
 // SimplifyWeeksToDays adds 7 * the weeks field to the days field, and sets the weeks field to zero.
-// See also SimplifyWeeks.
+// See also [Period.SimplifyWeeks].
 func (period Period) SimplifyWeeksToDays() Period {
 	wdays, _ := period.weeks.Mul(seven)
 	days, _ := wdays.Add(period.days)
@@ -119,7 +119,7 @@ func (period Period) SimplifyWeeksToDays() Period {
 // component unless the other components are zero. This is because ISO-8601 periods contain either
 // weeks or other fields but not both.
 //
-// See also SimplifyWeeksToDays.
+// See also [Period.SimplifyWeeksToDays].
 func (period Period) SimplifyWeeks() Period {
 	if period.years.Coef() != 0 || period.months.Coef() != 0 || period.days.Coef() != 0 ||
 		period.hours.Coef() != 0 || period.minutes.Coef() != 0 || period.seconds.Coef() != 0 {
@@ -141,7 +141,7 @@ func (period Period) SimplifyWeeks() Period {
 // it operates in either precise or approximate mode.
 //
 //   - Years may become multiples of 12 months if the number of months is non-zero - both modes.
-//   - Weeks - see SimplifyWeeks - both modes.
+//   - Weeks - see [Period.SimplifyWeeks] - both modes.
 //   - Days may become multiples of 24 hours if the number of hours is non-zero - approximate mode only
 //   - Hours may become multiples of 60 minutes if the number of minutes is non-zero - both modes.
 //   - Minutes may become multiples of 60 seconds if the number of seconds is non-zero - both modes.

--- a/parse.go
+++ b/parse.go
@@ -9,7 +9,7 @@ import (
 	"github.com/govalues/decimal"
 )
 
-// MustParse is as per Parse except that it panics if the string cannot be parsed.
+// MustParse is as per [period.Parse] except that it panics if the string cannot be parsed.
 // This is intended for setup code; don't use it for user inputs.
 func MustParse[S ISOString | string](isoPeriod S) Period {
 	p, err := Parse(isoPeriod)
@@ -24,7 +24,7 @@ func MustParse[S ISOString | string](isoPeriod S) Period {
 // In addition, a plus or minus sign can precede the period, e.g. "-P10D"
 //
 // It is possible to mix a number of weeks with other fields (e.g. P2M1W), although
-// this would not be allowed by ISO-8601. See SimplifyWeeks.
+// this would not be allowed by ISO-8601. See [Period.SimplifyWeeks].
 //
 // The zero value can be represented in several ways: all of the following
 // are equivalent: "P0Y", "P0M", "P0W", "P0D", "PT0H", PT0M", PT0S", and "P0".
@@ -40,7 +40,7 @@ func Parse[S ISOString | string](isoPeriod S) (Period, error) {
 // In addition, a plus or minus sign can precede the period, e.g. "-P10D"
 //
 // It is possible to mix a number of weeks with other fields (e.g. P2M1W), although
-// this would not be allowed by ISO-8601. See SimplifyWeeks.
+// this would not be allowed by ISO-8601. See [Period.SimplifyWeeks].
 //
 // The zero value can be represented in several ways: all of the following
 // are equivalent: "P0Y", "P0M", "P0W", "P0D", "PT0H", PT0M", PT0S", and "P0".

--- a/period.go
+++ b/period.go
@@ -41,7 +41,7 @@ var Zero = Period{}
 //-------------------------------------------------------------------------------------------------
 
 // NewYMD creates a simple period without any fractional parts. The fields are initialised verbatim
-// without any normalisation; e.g. 12 months will not become 1 year. Use Normalise if you need to.
+// without any normalisation; e.g. 12 months will not become 1 year. Use [Period.Normalise] if you need to.
 //
 // This function is equivalent to NewYMWD(years, months, 0, days)
 func NewYMD(years, months, days int) Period {
@@ -49,19 +49,19 @@ func NewYMD(years, months, days int) Period {
 }
 
 // NewYMWD creates a simple period without any fractional parts. The fields are initialised verbatim
-// without any normalisation; e.g. 12 months will not become 1 year. Use Normalise if you need to.
+// without any normalisation; e.g. 12 months will not become 1 year. Use [Period.Normalise] if you need to.
 func NewYMWD(years, months, weeks, days int) Period {
 	return New(years, months, weeks, days, 0, 0, 0)
 }
 
 // NewHMS creates a simple period without any fractional parts. The fields are initialised verbatim
-// without any normalisation; e.g. 120 seconds will not become 2 minutes. Use Normalise if you need to.
+// without any normalisation; e.g. 120 seconds will not become 2 minutes. Use [Period.Normalise] if you need to.
 func NewHMS(hours, minutes, seconds int) Period {
 	return New(0, 0, 0, 0, hours, minutes, seconds)
 }
 
 // New creates a simple period without any fractional parts. The fields are initialised verbatim
-// without any normalisation; e.g. 120 seconds will not become 2 minutes. Use Normalise if you need to.
+// without any normalisation; e.g. 120 seconds will not become 2 minutes. Use [Period.Normalise] if you need to.
 func New(years, months, weeks, days, hours, minutes, seconds int) Period {
 	return Period{
 		years:   decimal.MustNew(int64(years), 0),
@@ -70,11 +70,12 @@ func New(years, months, weeks, days, hours, minutes, seconds int) Period {
 		days:    decimal.MustNew(int64(days), 0),
 		hours:   decimal.MustNew(int64(hours), 0),
 		minutes: decimal.MustNew(int64(minutes), 0),
-		seconds: decimal.MustNew(int64(seconds), 0)}.normaliseSign()
+		seconds: decimal.MustNew(int64(seconds), 0),
+	}.normaliseSign()
 }
 
 // MustNewDecimal creates a period from seven decimal values. The fields are trimmed but no normalisation
-// is applied, e.g. 120 seconds will not become 2 minutes. Use Normalise if you need to.
+// is applied, e.g. 120 seconds will not become 2 minutes. Use [Period.Normalise] if you need to.
 //
 // Periods only allow the least-significant non-zero field to contain a fraction. If any of the
 // more-significant fields is supplied with a fraction, this function panics.
@@ -87,7 +88,7 @@ func MustNewDecimal(years, months, weeks, days, hours, minutes, seconds decimal.
 }
 
 // NewDecimal creates a period from seven decimal values. The fields are trimmed but no normalisation
-// is applied, e.g. 120 seconds will not become 2 minutes. Use Normalise if you need to.
+// is applied, e.g. 120 seconds will not become 2 minutes. Use [Period.Normalise] if you need to.
 //
 // Periods only allow the least-significant non-zero field to contain a fraction. If any of the
 // more-significant fields is supplied with a fraction, an error will be returned. This can be safely
@@ -163,7 +164,7 @@ func NewDecimal(years, months, weeks, days, hours, minutes, seconds decimal.Deci
 }
 
 // NewOf converts a time duration to a Period.
-// The result just a number of seconds, possibly including a fraction. It is not normalised; see Normalise.
+// The result just a number of seconds, possibly including a fraction. It is not normalised; see [Period.Normalise].
 func NewOf(duration time.Duration) Period {
 	seconds := decimal.MustNew(int64(duration), 9).Trim(0)
 	return Period{seconds: seconds}.normaliseSign()
@@ -176,7 +177,7 @@ func NewOf(duration time.Duration) Period {
 //
 // If t2 is before t1, the result is a negative period.
 //
-// The result just a number of seconds, possibly including a fraction. It is not normalised; see Normalise.
+// The result just a number of seconds, possibly including a fraction. It is not normalised; see [Period.Normalise].
 //
 // Remember that the resultant period does not retain any knowledge of the calendar, so any subsequent
 // computations applied to the period can only be precise if they concern either the date (year, month,
@@ -297,7 +298,7 @@ func (period Period) DaysDecimal() decimal.Decimal {
 // DaysIncWeeks gets the whole number of days in the period, including all the weeks.
 // The result is d + (w * 7), given d days and w weeks.
 //
-// See also SimplifyWeeksToDays.
+// See also [Period.SimplifyWeeksToDays].
 func (period Period) DaysIncWeeks() int {
 	i, _, _ := period.DaysIncWeeksDecimal().Int64(0)
 	return int(i)
@@ -306,7 +307,7 @@ func (period Period) DaysIncWeeks() int {
 // DaysIncWeeksDecimal gets the number of days in the period, including all the weeks and including any
 // fraction present. The result is d + (w * 7), given d days and w weeks.
 //
-// See also SimplifyWeeksToDays.
+// See also [Period.SimplifyWeeksToDays].
 func (period Period) DaysIncWeeksDecimal() decimal.Decimal {
 	wdays, _ := period.weeks.Mul(seven)
 	days, _ := wdays.Add(period.days)

--- a/sql.go
+++ b/sql.go
@@ -29,8 +29,7 @@ func (period *Period) Scan(value interface{}) (err error) {
 	return err
 }
 
-// Value converts the period to an ISO-8601 string. It implements driver.Valuer,
-// https://golang.org/pkg/database/sql/driver/#Valuer
+// Value converts the period to an ISO-8601 string. It implements [driver.Valuer],
 func (period Period) Value() (driver.Value, error) {
 	return period.String(), nil
 }


### PR DESCRIPTION
I started looking at your project. I read the documentation, and I found out you were not using the feature brought in Go 1.19: [go doc links](https://tip.golang.org/doc/go1.19#go-doc)