### PR TITLE
Use the Gregorian year as the NormaliseDaysToYears threshold

### DIFF
--- a/normalise.go
+++ b/normalise.go
@@ -9,7 +9,6 @@ var (
 	twelve      = decimal.MustNew(12, 0)
 	twentyFour  = decimal.MustNew(24, 0)
 	sixty       = decimal.MustNew(60, 0)
-	threeSixSix = decimal.MustNew(366, 0)
 	daysPerYear = decimal.MustNew(3652425, 4) // by the Gregorian rule
 )
 
@@ -60,7 +59,8 @@ func (period Period) NormaliseDaysToYears() Period {
 
 	days := period.DaysIncWeeksDecimal()
 
-	if days.Cmp(threeSixSix) < 0 {
+	// the threshold is one Gregorian year, not 366 days
+	if days.Cmp(daysPerYear) < 0 {
 		return period
 	}
 

--- a/normalise_test.go
+++ b/normalise_test.go
@@ -121,6 +121,9 @@ func Test_NormaliseDaysToYears(t *testing.T) {
 		{input: "PT1S", expected: "PT1S"},
 
 		{input: "P365D", expected: "P365D"},
+		{input: "P365.2425D", expected: "P1Y"},
+		{input: "P365.5D", expected: "P1Y0.2575D"},
+		{input: "P52W1.2425D", expected: "P1Y"},
 		{input: "P366D", expected: "P1Y0.7575D"},
 		{input: "P367D", expected: "P1Y1.7575D"},
 		{input: "P1461D", expected: "P4Y0.03D"},


### PR DESCRIPTION
`NormaliseDaysToYears` documents its own threshold:

> Based on the Gregorian rule, there are assumed to be 365.2425 days per year.
> - Multiples of 365.2425 days become years

The entry guard compares against 366 instead, so every total in `[365.2425, 366)` is returned unaltered even though a whole year is extractable.

```go
p := period.MustParse("P365.2425D") // exactly one Gregorian year by the rule above
fmt.Println(p.NormaliseDaysToYears().Period())
```

| input | current | after |
|---|---|---|
| `P365.2425D` | `P365.2425D` | `P1Y` |
| `P365.5D` | `P365.5D` | `P1Y0.2575D` |
| `P52W1.2425D` | `P52W1.2425D` | `P1Y` |

The negated forms behave the same way, since `neg` recurses through this guard.

## The fix

Compare against `daysPerYear` -- the constant the function already divides by three lines later -- and drop the now-unused `threeSixSix`. Five lines including the three new table rows.

## Behaviour change

This is an observable change: a period whose days-including-weeks total lands in `[365.2425, 366)` now returns a years-bearing period where it previously returned the input untouched. Every existing row in `Test_NormaliseDaysToYears` keeps its exact current output -- I did not adjust any of them.

## Verification

`mage build coverage` (what the workflow runs): `ok github.com/rickb777/period 0.047s`, coverage 97.5%, `gofmt -l .` empty, `go vet` clean.

I checked the threshold from both sides rather than only confirming the new rows go green:

- revert the guard to `366` -- the three new rows fail
- tighten it to `365` -- your pre-existing `P365D -> P365D` row fails, because 365 days would then be reshuffled to `P52W1D`

So `daysPerYear` is the only value in that neighbourhood that satisfies both the old table and the new one.

I also ran a randomised invariant probe over 20,000 periods (fields swept +/-200) asserting that `Duration()` is preserved across `Normalise(true/false)`, `Simplify(true/false)`, `SimplifyWeeksToDays`, `Negate`, `Mul(2)` and the `Period()` round trip. No violations before or after the change.

## Unrelated observation

While probing I noticed `fieldDuration` (`arithmetic.go:216`) multiplies in `int64` without a range check, so `MustParse("PT9223372036854775807S").Duration()` returns `-1s` with `precise == true`, and `MustParse("P1000Y").DurationApprox()` returns `-1482371h9m7.419103232s`. The doc does say `time.Duration` tops out near 292 years, so you may consider that documented -- I left it out of this PR to keep it to one thing. Happy to open a separate one if you want it addressed.

---

Disclosure: AI-assisted. I found and prepared this with an AI assistant, and I ran and verified everything above myself.
